### PR TITLE
Fix typos

### DIFF
--- a/2014-15/seriea-i.txt
+++ b/2014-15/seriea-i.txt
@@ -180,7 +180,7 @@
   Juventus       7-0  Parma FC
   US Palermo     1-1  Udinese
   Fiorentina     0-1  SSC Napoli
-  Internazional  2-2  Hellas Verona
+  Internazionale 2-2  Hellas Verona
   AS Roma        3-0  Torino FC
 
 


### PR DESCRIPTION
After closer investigation, openfootball/football.json#3 seems to be caused by typos in the source data
