### PR TITLE
Fix spelling Capri -> Carpi

### DIFF
--- a/2016-17/seriea-ii.txt
+++ b/2016-17/seriea-ii.txt
@@ -41,14 +41,14 @@
       Napoli          1-1 Palermo
       Inter           3-0 Pescara
       Sampdoria       3-2 Roma
-      
+
       Pescara         1-2 Fiorentina  (19.Giornata)   02.02.
 
 23^ Giornata
 [Dom. 5.2.]
       Atalanta        2-0 Cagliari
       Palermo         1-0 Crotone
-      Roma            4-0 Fiorentina    
+      Roma            4-0 Fiorentina
       Juventus        1-0 Inter
       Pescara         2-6 Lazio
       Bologna         1-7 Napoli
@@ -59,7 +59,7 @@
 
       Bologna         0-1 Milan    (18.Giornata)    08.02.
       Crotone         0-2 Juventus (18.Giornata)    08.02.
-      
+
 24^ Giornata
 [Dom. 12.2.]
       Palermo         1-3 Atalanta
@@ -202,10 +202,10 @@
       Torino          1-1 Sampdoria
       Empoli          1-3 Sassuolo
       Bologna         4-0 Udinese
-      
+
  1. Absteiger Serie A 2016/17
       Pescara
-    
+
 35^ Giornata
 [Dom. 7.5.]
       Udinese         1-1 Atalanta
@@ -218,7 +218,7 @@
       Milan           1-4 Roma
       Lazio           7-3 Sampdoria
       Juventus        1-1 Torino
-      
+
 2. Absteiger Serie A 2016/17
       US Palermo
 
@@ -234,12 +234,12 @@
       Bologna          3-1 Pescara
       Inter            1-2 Sassuolo
       Crotone          1-0 Udinese
-      
+
 Aufsteiger in Serie A
-      SPAL 2013 Ferrara 
+      SPAL 2013 Ferrara
       Hellas Verona
-      
-Play-off um einen Aufsteiger Serie A 
+
+Play-off um einen Aufsteiger Serie A
       siehe weiter unten
 
 37^ Giornata
@@ -254,10 +254,10 @@ Play-off um einen Aufsteiger Serie A
       Chievo            3-5 Roma
       Udinese           1-1 Sampdoria
       Genoa             2-1 Torino
-      
+
 Meister Serie A 2016/17
       Juventus Turin
-      
+
 38^ Giornata
 [Dom. 28.5.]
       Atalanta          1-0 Chievo
@@ -270,28 +270,28 @@ Meister Serie A 2016/17
       Fiorentina        2-2 Pescara
       Torino            5-3 Sassuolo
       Inter             5-2 Udinese
-      
+
 3. Absteiger Serie A 2016/17
       Empoli FC
-      
+
 Play-off um einen Aufsteiger Serie A
 [Lu 22.5.]
-     AS Cittadella        1-2  Capri FC
+     AS Cittadella        1-2  Carpi FC
 [Ma 23.5.]
       Benevento Calcio    2-1  Spezia Calcio
-      
+
 [Vie 26.5.]
-      Capri FC            0-0  Frosinone Calcio
+      Carpi FC            0-0  Frosinone Calcio
 [Sa 27.5.]
       Benevento Calcio    1-0  AC Perugia Calcio
 [Lu 29.5.]
-      Frosinone Calcio    0-1  Capri FC
+      Frosinone Calcio    0-1  Carpi FC
 [Ma 30.5.]
       AC Perugia Calcio   1-1  Benevento Calcio
-      
+
 [Do 4.6.]
-      Capri FC - Benevento Calcio
-      
+      Carpi FC - Benevento Calcio
+
 [Jue 8.6.]
-      Benevento Calcio - Capri FC
-     
+      Benevento Calcio - Carpi FC
+


### PR DESCRIPTION
Fixes the spelling of a playoff team, see [Carpi's page Wikipedia](https://en.wikipedia.org/wiki/Carpi_F.C._1909) for reference.

Also some trailing space automatically trimmed by my editor, hope that's ok.