### PR TITLE
Insert start values for the 2021-22 season

### DIFF
--- a/2021-22/1-seriea.txt
+++ b/2021-22/1-seriea.txt
@@ -1,0 +1,48 @@
+= Italian Serie A 2021/22
+
+
+1^ Giornata
+[Sab. 21.8.]
+  18.30  Hellas Verona            2-3  US Sassuolo Calcio
+  18.30  FC Internazionale Milano 4-0  Genoa CFC
+  20.45  Empoli FC                1-3  SS Lazio
+  20.45  Torino FC                1-2  Atalanta Bergamo
+[Dom. 22.8.]
+  18.30  Bologna FC               3-2  US Salernitana
+  18.30  Udinese Calcio           2-2  Juventus Torino
+  20.45  SSC Napoli               2-0  Venezia Football Club
+  20.45  AS Roma                  2-1  ACF Fiorentina
+[Lun. 23.8.]
+  18.30  Cagliari Calcio          2-2  Spezia Calcio
+  20.45  UC Sampdoria             2-2  AC Milan
+
+
+2^ Giornata
+[Sab. 27.8.]
+  18.30  Udinese Calcio           3-0  Venezia Football Club
+  20.45  Hellas Verona            1-3  FC Internazionale Milano
+[Dom. 28.8.]
+  18.30  Atalanta Bergamo         0-0  Bologna FC
+  18.30  SS Lazio                 6-1  Spezia Calcio
+  20.45  ACF Fiorentina           2-1  Torino FC
+  20.45  Juventus Torino          0-1  Empoli FC
+[Lun. 29.8.]
+  18.30  Genoa CFC                1-2  SSC Napoli
+  18.30  US Sassuolo Calcio       0-0  UC Sampdoria
+  20.45  AC Milan                 4-1  Cagliari Calcio
+  20.45  US Salernitana           0-4 AS Roma  
+
+
+3^ Giornata
+[Dom. 12.9.]
+  Atalanta Bergamo         -  ACF Fiorentina
+  Bologna FC               -  Hellas Verona
+  Cagliari Calcio          -  Genoa CFC
+  Empoli FC                -  Venezia Football Club
+  AC Milan                 -  SS Lazio
+  SSC Napoli               -  Juventus Torino
+  AS Roma                  -  US Sassuolo Calcio
+  UC Sampdoria             -  FC Internazionale Milano
+  Spezia Calcio            -  Udinese Calcio
+  Torino FC                -  US Salernitana
+  

--- a/clubs/clubs.props.txt
+++ b/clubs/clubs.props.txt
@@ -32,3 +32,6 @@ hellasverona, Hellas Verona,             HEL
 cesena,       AC Cesena
 spal,         SPAL 2013 Ferrara
 benevento,    Benevento Calcio
+spezia,       Spezia Calcio              SPE
+venezia,      Venezia Football Club      VEN
+salernitana,  US Salernitana             SAL


### PR DESCRIPTION
Hi,
in the next lines you can find the changelog:

- updated clubs.props.txt with the name of serie A teams for the 2021-22 season
- created 2021-22/1-seriea.txt with the first three matchdays (1^, 2^ and 3^)

I have also a question, how can update football.json/2021-22/it.1.json from this commit?

Best regards.